### PR TITLE
[start]customer-item

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,2 +1,12 @@
 class ItemsController < ApplicationController
+  
+  def index
+    @items = Item.all.page(params[:page]).per(8)
+  end
+  
+  def show
+    @item = Item.find(params[:id])
+    @cart_item = CartItem.new
+  end
+  
 end

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,6 +1,11 @@
 <div class="container">
   <div class="row no-gutters my-5">
     <h5 class="text-dark bg-light p-1 mb-0">商品一覧</h5>
+    <%= link_to new_admin_item_path do %>
+      <div class="float-right">
+        <button type="button" class="btn btn-dark rounded-circle p-0" style="width:3rem;height:3rem;">＋</button>   <!--右寄せにする-->
+      </div>
+    <% end %>
   </div>
   <div class="row">
     <table class="table">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <div class="row">
+    <div class="offset-md-1 col-md-10">
+      <h3 class="mb-3">商品一覧<span class="small">(全<%= @items.count %>件)</span></h3>
+  
+      <div style="display: flex; flex-wrap: wrap; justify-content: center;">
+        <% @items.each do |item| %>
+          <div style="margin-right: 10px; margin-bottom: 10px;">
+            <p>
+              <%= link_to item_path(item) do %>
+              <%= attachment_image_tag item, :image, size: "180x130" %>
+              <% end %>
+            </p>
+            <p><%= item.name %></p>
+            <p>¥<%= item.price.to_s(:delimited) %></p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row">
+    <div class="text-center mx-auto mb-3">
+      <%= paginate @items %>
+    </div>
+  </div>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,23 @@
+<div class="container">
+  <div class="row">
+    <div class="offset-md-1 col-md-4" style="margin-bottom: 30%;">
+      <%= attachment_image_tag @item, :image, size: "280x180" %>
+    </div>
+
+    <div class="col-md-6">
+      <h4><%= @item.name %></h4>
+      <p style="height: 100px"><%= @item.introduction %></p>
+      <p><strong style="font-size: 22px; margin-right: 4px;">¥ <%= (@item.price * 1.1).to_i.to_s(:delimited) %></strong><span style="font-size: 12px;">(税込)</span></p>
+
+      <div class="form-inline">
+      <% if customer_signed_in? %>
+        <%= form_with(model: @cart_item, url: cart_items_path, method: :post, local:true) do |f| %>
+          <%= f.hidden_field :item_id, value: @item.id %>
+          <%= f.select :count, (1..10).to_a, include_blank: "個数選択" %>
+          <%= f.submit "カートに入れる", class: "btn btn-success" %>
+        <% end %>
+      <% end %>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
管理者側の商品一覧ページに、新規投稿画面へのリンクを追加。
顧客側の商品一覧ページ、詳細ページを作成。

詳細ページ内の「カートに入れる」のところは、form_with内にhidden_fieldを作ることで、item_idのデータを一緒に送ることができるそうです。
イメージの投稿がない場合のデフォルトイメージの作成や、細かいレイアウト等は後ほど行います。
商品詳細ページがないとカートに進めないので、先にプルリクしました。
確認をお願いします。